### PR TITLE
Updated docs for VisualStudio param

### DIFF
--- a/app/templates/documentation.hbs
+++ b/app/templates/documentation.hbs
@@ -123,15 +123,15 @@
 </thead><tbody>
 <tr>
 <td><code>run &lt;platform&gt;</code></td>
-<td>Launches the app of the specified platform. Currently, only <em>android</em> and <em>windows</em> platforms are supported by this command</td>
+<td>Launches the app of the specified platform. Currently, only <em>android</em> and <em>windows</em> platforms are supported by this command.</td>
 </tr>
 <tr>
-<td><code>visualstudio</code></td>
-<td>(for Windows only) Opens the project file of the generated Windows 8.1 / Windows 10 app in Visual Studio</td>
+<td><code>open &lt;windows|windows10&gt;</code></td>
+<td>(for Windows only) Opens the project file of the generated Windows app in Visual Studio.</td>
 </tr>
 <tr>
 <td><code>package &lt;content-directory&gt; &lt;output-package-path&gt;</code></td>
-<td>Creates an APPX package for uploading the Windows 10 app to the Store, where <em>&lt;content-directory&gt;</em> is the folder that contains the app contents, including the <strong>appmanifest.xml</strong> file and the app's icons, and <em>&lt;output-package-path&gt;</em> is the path to the APPX file to be generated</td>
+<td>Creates an APPX package for uploading the Windows 10 app to the Store, where <em>&lt;content-directory&gt;</em> is the folder that contains the app contents, including the <strong>appmanifest.xml</strong> file and the app's icons, and <em>&lt;output-package-path&gt;</em> is the path to the APPX file to be generated.</td>
 </tr>
 </tbody></table>
 


### PR DESCRIPTION
visualstudio param deprecated, runtime tells you correct replacement.  I just updated the docs.
