### PR TITLE
Fixed manifest issues on "generate manifest" page.

### DIFF
--- a/pages/_lang/generate.vue
+++ b/pages/_lang/generate.vue
@@ -319,16 +319,14 @@ export default class extends Vue {
     let manifest = '';
       for (let property in this.manifest) {
         if (property !== 'icons') {
-          manifest += `"${property}"; : "${this.manifest[property]}",
+          manifest += `"${property}" : "${this.manifest[property]}",
     `;
         }
       }
-      manifest += `'icons' : [${this.getIcons()}
+      manifest += `"icons" : [${this.getIcons()}
     ]`;
       manifest += this.getCustomMembers();
-    return `{
-    ${manifest}
-}`;
+    return `{${manifest}}`;
   }
 
   public getCode(): string | null {


### PR DESCRIPTION
After reviewing the production site, I found out that the displayed manifest is generated with two issues: 
o	Between the property quotation marks and the colon, the application adds an extra semicolon.
o	The use of apostrophes on the icons properties instead of quotation marks.

I fixed both issues with this branch.
